### PR TITLE
refine flag parsing and add tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  flag-parsing-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.15, 1.16, 1.17, 1.18]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - run: go run cmd/auth/main.go | grep "Update your .netrc file to work with Google Cloud Artifact Registry Go Repositories."
+    - run: go run cmd/auth/main.go --help | grep "Commands:"
+    - run: go run cmd/auth/main.go bad-command | grep "unknown command %q"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17, 1.18]
+        go-version: [1.18]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
@@ -19,4 +19,4 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - run: go run cmd/auth/main.go | grep "Update your .netrc file to work with Google Cloud Artifact Registry Go Repositories."
     - run: go run cmd/auth/main.go --help | grep "Commands:"
-    - run: go run cmd/auth/main.go bad-command | grep "unknown command %q"
+    - run: go run cmd/auth/main.go bad-command | grep 'unknown command \"''

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Integration Tests
 
 on:
   push:
@@ -20,4 +20,3 @@ jobs:
     - run: go run cmd/auth/main.go | grep "Update your .netrc file to work with Google Cloud Artifact Registry Go Repositories."
     - run: go run cmd/auth/main.go --help | grep "Commands:"
     - run: go run cmd/auth/main.go bad-command | grep 'unknown command "bad-command"'
-    

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,4 +19,5 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - run: go run cmd/auth/main.go | grep "Update your .netrc file to work with Google Cloud Artifact Registry Go Repositories."
     - run: go run cmd/auth/main.go --help | grep "Commands:"
-    - run: go run cmd/auth/main.go bad-command | grep 'unknown command \"''
+    - run: go run cmd/auth/main.go bad-command | grep 'unknown command "bad-command"'
+    

--- a/cmd/auth/main.go
+++ b/cmd/auth/main.go
@@ -37,6 +37,7 @@ Commands:
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println(help)
+		return
 	}
 	switch os.Args[1] {
 	case "refresh":
@@ -48,6 +49,10 @@ func main() {
 		locations := addLocationFlags.String("locations", "", "Required. A list of comma-separated location strings to regional Artifact Registry Go endpoints to the netrc file.")
 		addLocationFlags.Parse(os.Args[2:])
 		addLocations(*locations, *jsonKey, *hostPattern)
+	case "help", "-help", "--help":
+		fmt.Println(help)
+	default:
+		fmt.Printf("unknown command %q. Please rerun the tool with `--help`\n", os.Args[1])
 	}
 }
 


### PR DESCRIPTION
Fix a few bugs in the flag parsing:
- return immediately if no subcommand is given
- show help text when --help, -help or help exist
- error and prompt user to run --help for other input

Also add an integration test for flag parsing. 