### PR TITLE
Fix handling of NETRC environment variable in Load

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.15, 1.16, 1.17, 1.18]
+        go-version: [1.16, 1.17, 1.18]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/pkg/netrc/netrc.go
+++ b/pkg/netrc/netrc.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/artifact-registry-go-tools/pkg/auth"
 )
@@ -53,7 +54,17 @@ func Load() (string, string, error) {
 		netrcPath = h
 	}
 
-	netrcPath = path.Join(netrcPath, ".netrc")
+	if !strings.HasSuffix(netrcPath, ".netrc") {
+		netrcPath = path.Join(netrcPath, ".netrc")
+	}
+
+	if _, err := os.Stat(path.Dir(netrcPath)); err != nil {
+		if os.IsNotExist(err) {
+			return "", "", fmt.Errorf(".netrc directory does not exist: %w", err)
+		}
+		return "", "", fmt.Errorf("failed to load .netrc directory: %w", err)
+	}
+
 	data, err := ioutil.ReadFile(netrcPath)
 	if os.IsNotExist(err) {
 		//  The .netrc file does not exist; create a new one

--- a/pkg/netrc/testdata/load_test/has_netrc_file_dir/.netrc
+++ b/pkg/netrc/testdata/load_test/has_netrc_file_dir/.netrc
@@ -1,0 +1,3 @@
+machine example.com
+login username
+password password


### PR DESCRIPTION
The current Load implementation assumes NETRC environment variable is a directory.

However, other products like Go and Inetutils expect NETRC to be a file path.
This discrepancy causes issues depending on usage.

Updated to allow artifact-registry-go-tools to work with NETRC as a file path.

Ensured backward compatibility so it still works if NETRC is a directory path.