### PR TITLE
Add Windows support

### DIFF
--- a/pkg/netrc/netrc_test.go
+++ b/pkg/netrc/netrc_test.go
@@ -233,11 +233,12 @@ var hasNetrcFileDirNetrcContent string
 
 func TestLoad(t *testing.T) {
 	currentDir, err := os.Getwd()
-	netrcFileName := getNetrcFileName()
-
 	if err != nil {
 		t.Fatalf("os.Getwd() = %v", err)
 	}
+
+	netrcFileName := getNetrcFileName()
+
 	testDataDir := filepath.Join(currentDir, "testdata", "load_test")
 
 	cases := []struct {

--- a/pkg/netrc/netrc_test.go
+++ b/pkg/netrc/netrc_test.go
@@ -239,8 +239,6 @@ func TestLoad(t *testing.T) {
 		t.Fatalf("os.Getwd() = %v", err)
 	}
 	testDataDir := filepath.Join(currentDir, "testdata", "load_test")
-	a := testDataDir
-	_ = a
 
 	cases := []struct {
 		name             string

--- a/pkg/netrc/netrc_test.go
+++ b/pkg/netrc/netrc_test.go
@@ -41,7 +41,7 @@ password <oauth2accesstoken>
 			jsonKeyPath: "testdata/key.json",
 			wantNetrc: `machine us-west1-go.pkg.dev
 login _json_key_base64
-password ewogICAgInRlc3Qta2V5IjogInRlc3QtdmFsdWUiCn0=
+password eyJ0ZXN0LWtleSI6ICJ0ZXN0LXZhbHVlIn0=
 `,
 		},
 		{

--- a/pkg/netrc/netrc_test.go
+++ b/pkg/netrc/netrc_test.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"errors"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -233,10 +233,14 @@ var hasNetrcFileDirNetrcContent string
 
 func TestLoad(t *testing.T) {
 	currentDir, err := os.Getwd()
+	netrcFileName := getNetrcFileName()
+
 	if err != nil {
 		t.Fatalf("os.Getwd() = %v", err)
 	}
-	testDataDir := path.Join(currentDir, "testdata", "load_test")
+	testDataDir := filepath.Join(currentDir, "testdata", "load_test")
+	a := testDataDir
+	_ = a
 
 	cases := []struct {
 		name             string
@@ -247,29 +251,29 @@ func TestLoad(t *testing.T) {
 	}{
 		{
 			name:             "NETRC env points to existing directory",
-			netrcPath:        path.Join(testDataDir, "empty_dir"),
-			wantNetrcPath:    path.Join(testDataDir, "empty_dir", ".netrc"),
+			netrcPath:        filepath.Join(testDataDir, "empty_dir"),
+			wantNetrcPath:    filepath.Join(testDataDir, "empty_dir", netrcFileName),
 			wantNetrcContent: "",
 			wantErr:          nil,
 		},
 		{
 			name:             "NETRC env points to non-existent directory",
-			netrcPath:        path.Join(testDataDir, "non_existent_dir"),
+			netrcPath:        filepath.Join(testDataDir, "non_existent_dir"),
 			wantNetrcPath:    "",
 			wantNetrcContent: "",
 			wantErr:          os.ErrNotExist,
 		},
 		{
 			name:             "NETRC env points to existing file",
-			netrcPath:        path.Join(testDataDir, "has_netrc_file_dir", ".netrc"),
-			wantNetrcPath:    path.Join(testDataDir, "has_netrc_file_dir", ".netrc"),
+			netrcPath:        filepath.Join(testDataDir, "has_netrc_file_dir", netrcFileName),
+			wantNetrcPath:    filepath.Join(testDataDir, "has_netrc_file_dir", netrcFileName),
 			wantNetrcContent: hasNetrcFileDirNetrcContent,
 			wantErr:          nil,
 		},
 		{
 			name:             "NETRC env points to non-existent file",
-			netrcPath:        path.Join(testDataDir, "empty_dir", ".netrc"),
-			wantNetrcPath:    path.Join(testDataDir, "empty_dir", ".netrc"),
+			netrcPath:        filepath.Join(testDataDir, "empty_dir", netrcFileName),
+			wantNetrcPath:    filepath.Join(testDataDir, "empty_dir", netrcFileName),
 			wantNetrcContent: "",
 			wantErr:          nil,
 		},

--- a/pkg/netrc/testdata/key.json
+++ b/pkg/netrc/testdata/key.json
@@ -1,3 +1,1 @@
-{
-    "test-key": "test-value"
-}
+{"test-key": "test-value"}

--- a/pkg/netrc/testdata/load_test/has_netrc_file_dir/_netrc
+++ b/pkg/netrc/testdata/load_test/has_netrc_file_dir/_netrc
@@ -1,0 +1,3 @@
+machine example.com
+login username
+password password


### PR DESCRIPTION
- [x] Fixes https://github.com/GoogleCloudPlatform/artifact-registry-go-tools/issues/14
- [x] Switch from path to path/filepath for multi-platform line separators
- [x] Fix the AddConfigs test for Windows by removing the new lines in the test data. Different new line characters in Windows were causing tests always to fail