### PR TITLE
Add `goauth` binary for `GOAUTH` environment support

### DIFF
--- a/cmd/goauth/main.go
+++ b/cmd/goauth/main.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/GoogleCloudPlatform/artifact-registry-go-tools/pkg/auth"
+)
+
+const help = `
+Handle Go authentication with Google Cloud Artifact Registry Go Repositories.
+
+Add to your GOAUTH environment variable:
+
+  export GOAUTH="sh -c 'GOPROXY=direct go run github.com/GoogleCloudPlatform/artifact-registry-go-tools/cmd/goauth@latest <location>'"
+
+To support multiple locations, add the command multiple times to the GOAUTH variable (semicolon-separated).
+
+For more details, see https://pkg.go.dev/cmd/go@master#hdr-GOAUTH_environment_variable`
+
+func main() {
+	jsonKey := flag.String("json_key", "", "path to the json key of the service account used for this location. Leave empty to use the oauth token instead.")
+	hostPattern := flag.String("host_pattern", "%s-go.pkg.dev", "Artifact Registry server host pattern, where %s will be replaced by a location string.")
+
+	flag.Parse()
+
+	location := flag.Arg(0)
+	if location == "" {
+		fmt.Println(help)
+		return
+	}
+
+	err := handleLocation(location, *jsonKey, *hostPattern)
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}
+
+func handleLocation(location string, jsonKeyPath string, hostPattern string) error {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	host := fmt.Sprintf(hostPattern, location)
+	url := fmt.Sprintf("https://%s", host)
+	var authorization string
+
+	if jsonKeyPath != "" {
+		key, err := auth.EncodeJsonKey(jsonKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to encode JSON key: %w", err)
+		}
+
+		authorization = basicAuthHeader("_json_key_base64", key)
+	} else {
+		token, err := auth.Token(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get oauth token: %w", err)
+		}
+
+		authorization = basicAuthHeader("oauth2accesstoken", token)
+	}
+
+	// send the Go authentication information
+	fmt.Printf("%s\n\nAuthorization: %s\n\n", url, authorization)
+
+	return nil
+}
+
+func basicAuthHeader(username, password string) string {
+	a := fmt.Sprintf("%s:%s", username, password)
+	b := base64.StdEncoding.EncodeToString([]byte(a))
+
+	return fmt.Sprintf("Basic %s", b)
+}

--- a/cmd/goauth/main.go
+++ b/cmd/goauth/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	location := flag.Arg(0)
 	if location == "" {
-		fmt.Println(help)
+		fmt.Fprintln(os.Stderr, help)
 		return
 	}
 	if strings.HasPrefix(location, "https://") {

--- a/cmd/goauth/main.go
+++ b/cmd/goauth/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/artifact-registry-go-tools/pkg/auth"
@@ -46,6 +47,10 @@ func main() {
 	if location == "" {
 		fmt.Println(help)
 		return
+	}
+	if strings.HasPrefix(location, "https://") {
+		log.Println("Location has to be a Google Cloud region, e.g. 'us-central1'.")
+		os.Exit(2)
 	}
 
 	err := handleLocation(location, *jsonKey, *hostPattern)

--- a/cmd/goauth/main_test.go
+++ b/cmd/goauth/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestLocationURL(t *testing.T) {
+	url := locationURL("us-central1", defaultHostPattern)
+
+	if url != "https://us-central1-go.pkg.dev" {
+		t.Fatalf("unexpected url: %s", url)
+	}
+}
+
+func TestAuthHeader_DefaultCredentials(t *testing.T) {
+	header, err := keyAuthHeader("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("header: %s", header)
+
+	if !strings.HasPrefix(header, "Basic ") {
+		t.Fatal(err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(header[6:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("decoded: %s", decoded)
+
+	if !strings.HasPrefix(string(decoded), "oauth2accesstoken:") {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthHeader_JSONKey(t *testing.T) {
+	header, err := keyAuthHeader("./test/dummy.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("header: %s", header)
+
+	if !strings.HasPrefix(header, "Basic ") {
+		t.Fatal(err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(header[6:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("decoded: %s", decoded)
+
+	if !strings.HasPrefix(string(decoded), "_json_key_base64:") {
+		t.Fatal(err)
+	}
+}

--- a/cmd/goauth/test/dummy.json
+++ b/cmd/goauth/test/dummy.json
@@ -1,0 +1,1 @@
+{ "comment": "the content of this file is irrelevant" }


### PR DESCRIPTION
This adds support for the new `GOAUTH` environment variable, introduced by Go 1.24.

Note: I have not tested the service account support, but it should work. Please feel free to contribute some testing ;) . 

Fixes #21 

# How I tested (binary)

1. Run go build in `cmd/goauth`
2. `export GOAUTH="/home/felix/Projects/artifact-registry-go-tools/cmd/goauth/goauth europe-west1"`
3. `go get -u golang.org/x/net`


# How I tested (script)

1. `export GOAUTH="sh -c 'GOPROXY=direct go run github.com/smartpricer/artifact-registry-go-tools/cmd/goauth@latest europe-west1'"` (obviously using the fork)
2. `go get -u golang.org/x/net`

