### PR TITLE
Upgrade Go version to 1.26, Remove Go 1.25 from test workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25, 1.26]
+        go-version: [1.26]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,7 @@
 name: Integration Tests
 
+permissions: read-all
+
 on:
   push:
     branches: [ "main" ]
@@ -16,8 +18,8 @@ jobs:
       matrix:
         go-version: [1.26]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ matrix.go-version }}
     - run: go run cmd/auth/main.go | grep "Update your .netrc file to work with Google Cloud Artifact Registry Go Repositories."

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25, 1.26]
+        go-version: [1.26]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: read-all
+
 on:
   push:
     branches: [ "main" ]
@@ -13,8 +15,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: 1.26
     - name: gofmt
@@ -27,8 +29,8 @@ jobs:
       matrix:
         go-version: [1.26]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ matrix.go-version }}
     - run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/GoogleCloudPlatform/artifact-registry-go-tools
 
-go 1.25.0
+go 1.26.0
+
+toolchain go1.26.5
 
 require golang.org/x/oauth2 v0.36.0
 


### PR DESCRIPTION
Upgrade Go version to 1.26.0 and toolchain to 1.26.4.

TAG=agy
CONV=fb268476-f9d2-436f-9f9b-25556af906f8